### PR TITLE
chore: updating documentation to include AUTH_SECRET

### DIFF
--- a/apps/docs/src/routes/getting-started/+page.md
+++ b/apps/docs/src/routes/getting-started/+page.md
@@ -32,6 +32,10 @@ DOMAIN=http://localhost:5173
 # For examples, see: https://www.prisma.io/docs/orm/reference/connection-urls
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/mydb?schema=public"
 
+# Secret for Auth.js to encrypt tokens
+# Can be generated with: pnpx auth secret
+AUTH_SECRET=
+
 # Client Id and Client Secret of GitHub OAuth app
 # In GitHub: Settings -> Developer Settings -> OAuth Apps
 GITHUB_ID=


### PR DESCRIPTION
Added instructions in the documentation on how to generate the `AUTH_SECRET` needed for Auth.js.

https://authjs.dev/getting-started/installation?framework=sveltekit#setup-environment

Closes: #6 
