### PR TITLE
Tracks user purchases

### DIFF
--- a/apps/app/prisma/schema.prisma
+++ b/apps/app/prisma/schema.prisma
@@ -49,6 +49,7 @@ model User {
   subscriptionStatus SubscriptionStatus?
   plan               String?
   priceId            String?
+  purchases          Json @default("[]")
 }
 
 // customization for AirBadge

--- a/apps/docs/src/routes/getting-started/+page.md
+++ b/apps/docs/src/routes/getting-started/+page.md
@@ -106,6 +106,7 @@ model User {
   subscriptionStatus SubscriptionStatus?
   plan               String?
   priceId            String?
+  purchases          Json @default("[]")
 }
 
 // customization for AirBadge

--- a/apps/docs/src/routes/session/+page.md
+++ b/apps/docs/src/routes/session/+page.md
@@ -59,9 +59,9 @@ This is an example of what session data would look like:
     "emailVerified": null,
     "image": "https://avatars.githubusercontent.com/u/###"
   },
+  "customerId": "cus_1234",
   "subscription": {
     "id": "sub_1234",
-    "customerId": "cus_1234",
     "status": "active",
     "priceId": "price_1234",
     "plan": "basic_monthly"

--- a/packages/sveltekit/prisma/schema.prisma
+++ b/packages/sveltekit/prisma/schema.prisma
@@ -49,6 +49,7 @@ model User {
   subscriptionStatus SubscriptionStatus?
   plan               String?
   priceId            String?
+  purchases          Json @default("[]")
 }
 
 enum SubscriptionStatus {

--- a/packages/sveltekit/src/lib/index.js
+++ b/packages/sveltekit/src/lib/index.js
@@ -37,14 +37,29 @@ function authHandler(options) {
       async session({ session }) {
         const user = await options.adapter.getUserByEmail(session.user.email)
 
+        if (user?.customerId) {
+          session.customerId = user.customerId
+        }
+
         if (user?.subscriptionId) {
           session.subscription = {
             id: user.subscriptionId,
-            customerId: user.customerId,
             priceId: user.priceId,
             plan: user.plan,
             status: user.subscriptionStatus.toLowerCase()
           }
+        }
+
+        if (user?.purchases) {
+          let purchases = []
+
+          user.purchases.forEach(({ productId, priceId, lookupKey }) => {
+            purchases.push(productId)
+            purchases.push(priceId)
+            purchases.push(lookupKey)
+          })
+
+          session.purchases = purchases
         }
 
         if (options?.callbacks?.session) {

--- a/packages/sveltekit/tests/signIn.test.js
+++ b/packages/sveltekit/tests/signIn.test.js
@@ -33,12 +33,40 @@ test('sign in with subscription', async ({ page }) => {
       email: user.email,
       name: user.name
     },
+    customerId: 'cus_1234',
     subscription: {
       id: 'sub_1234',
-      customerId: 'cus_1234',
       status: 'active',
       priceId: 'price_1234',
       plan: 'pro',
     }
+  })
+})
+
+test('sign in with purchases', async ({ page }) => {
+  const user = await createUser({
+    customerId: 'cus_1234',
+    purchases: [
+      { priceId: 'price_123', productId: 'prod_123', lookupKey: 't-shirt'},
+      { priceId: 'price_456', productId: 'prod_456', lookupKey: 'socks'}
+    ]
+  })
+
+  const session = await signIn(page, user)
+
+  expect(session).toMatchObject({
+    user: {
+      email: user.email,
+      name: user.name
+    },
+    customerId: 'cus_1234',
+    purchases: [
+      'prod_123',
+      'price_123',
+      't-shirt',
+      'prod_456',
+      'price_456',
+      'socks'
+    ]
   })
 })


### PR DESCRIPTION
Tracks user purchases in `User` model.

- Adds a new field `purchases` to the `User` model.
- Tracks each purchase after checkout completes.
- Adds a `session.purchases` field which can be used to gate content.

To gate server-side:

```javascript
if (!session?.purchases.includes('e-book')) {
  error(403, 'Access denied')
}
```

To gate in a component:

```svelte
<script>
  export let data
</script>

{#if session?.purchases.includes('e-book')}
  <a href="/download">Download e-book</a>
{/if}
```